### PR TITLE
fix: setting trailingComma to es5

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -10,6 +10,9 @@ module.exports = {
   // arrowParens default since Prettier v2.0.0 is "always"
   // "avoid" present to avoid reformatting pre v2.0 code.
   arrowParens: "avoid",
+  // trailingComma default since Prettier v3 is "all"
+  // setting to "es5" for nicer formatting of JSX and less formatting changes.
+  trailingComma: "es5",
   // Cypress overrides: allow longer lines
   overrides: [
     {


### PR DESCRIPTION
Default value for trailingComma was changed from es5 to all from prettier version 2 to 3.
To me es5 looks nicer, especially for JSX syntax and is more intuitive as it tells me this is the last parameter.

https://prettier.io/docs/en/options.html#trailing-commas