### PR TITLE
fix: default to arrowParens=always

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -7,9 +7,6 @@
 
 // https://prettier.io/docs/en/options.html
 module.exports = {
-  // arrowParens default since Prettier v2.0.0 is "always"
-  // "avoid" present to avoid reformatting pre v2.0 code.
-  arrowParens: "avoid",
   // trailingComma default since Prettier v3 is "all"
   // setting to "es5" for nicer formatting of JSX and less formatting changes.
   trailingComma: "es5",


### PR DESCRIPTION
Bring back the default value for arrowParens (=always)